### PR TITLE
Installer update

### DIFF
--- a/installer/HashCheck.nsi
+++ b/installer/HashCheck.nsi
@@ -73,7 +73,7 @@ VIAddVersionKey /LANG=${LANG_ENGLISH} "FileVersion" "2.2.2.5"
 Section
 
     GetTempFileName $0
-    File /oname=$0 ..\bin.x86-32\HashCheck.dll
+    File /oname=$0 ..\bin\Win32\Release\HashCheck.dll
     ExecWait 'regsvr32 /i /n /s "$0"'
     IfErrors abort_on_error
     Delete $0
@@ -94,7 +94,7 @@ Section
     ${If} ${RunningX64}
         ${DisableX64FSRedirection}
 
-        File /oname=$0 ..\bin.x86-64\HashCheck.dll
+        File /oname=$0 ..\bin\x64\Release\HashCheck.dll
         ExecWait 'regsvr32 /i /n /s "$0"'
         IfErrors abort_on_error
         Delete $0

--- a/installer/HashCheck.nsi
+++ b/installer/HashCheck.nsi
@@ -52,15 +52,18 @@ FunctionEnd
 !insertmacro MUI_LANGUAGE "Turkish"
 !insertmacro MUI_LANGUAGE "Ukrainian"
 
-VIProductVersion "2.2.2.5"
+!define APP_VER 3.0.1.0
+!define REPO https://github.com/modelrockettier/HashCheck
+
+VIProductVersion "${APP_VER}"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductName" "HashCheck Shell Extension"
-VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductVersion" "2.2.2.5"
-VIAddVersionKey /LANG=${LANG_ENGLISH} "Comments" "Installer distributed from https://github.com/chappjc/HashCheck/releases"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductVersion" "${APP_VER}"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "Comments" "Installer distributed from ${REPO}/releases"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "CompanyName" ""
 VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalTrademarks" ""
-VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalCopyright" "Copyright © Kai Liu and Christopher Gurnee."
-VIAddVersionKey /LANG=${LANG_ENGLISH} "FileDescription" "Installer (x86/x64) from https://github.com/chappjc/HashCheck/releases"
-VIAddVersionKey /LANG=${LANG_ENGLISH} "FileVersion" "2.2.2.5"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalCopyright" "Copyright © Kai Liu, Christopher Gurnee, David B. Trout, Tim Schlueter."
+VIAddVersionKey /LANG=${LANG_ENGLISH} "FileDescription" "HashCheck installer (x86/x64), distributed from ${REPO}/releases"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "FileVersion" "${APP_VER}"
 
 ; With solid compression, files that are required before the
 ; actual installation should be stored first in the data block,


### PR DESCRIPTION
I was happy to see you had an updated fork of this useful project, thanks! Was a little sad when there were no installers on the Releases page, but I figured that was something I could fix :) I gently cleaned up the NSIS installer script so that it actually looks for the binaries where visual studio spits them out, and updated the metadata so it's up to date and that it's less of a chore to keep up to date (only once place to update the version, etc).

I tested building this with VS2013 Community and a recent NSIS 3.0 beta (though it should work with older NSIS versions I imagine). Should be a fairly simple process of just building release in both architectures then right-clicking the nsi script and choosing "Compile" to get an installer now that you can add to a release/tag on GitHub.
