### PR TITLE
Generate version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /Bin
 /Obj
 /installer/*.exe
+Release/
+Debug/

--- a/HashCheck.cpp
+++ b/HashCheck.cpp
@@ -311,20 +311,15 @@ HRESULT Install( BOOL bCopyFile )
 				TCHAR szUninstall[MAX_PATH << 1];
 				wnsprintf(szUninstall, countof(szUninstall), TEXT("regsvr32.exe /u /i /n \"%s\""), lpszTargetPath);
 
-				static const TCHAR szURLFull[] = TEXT("http://code.kliu.org/hashcheck/");
-				TCHAR szURLBase[countof(szURLFull)];
-				SSStaticCpy(szURLBase, szURLFull);
-				szURLBase[21] = 0; // strlen("http://code.kliu.org/")
-
 				RegSetSZ(hKey, TEXT("DisplayIcon"), lpszTargetPath);
 				RegSetSZ(hKey, TEXT("DisplayName"), TEXT(HASHCHECK_NAME_STR) TEXT(ARCH_NAME_TAIL));
 				RegSetSZ(hKey, TEXT("DisplayVersion"), TEXT(HASHCHECK_VERSION_STR));
-				RegSetSZ(hKey, TEXT("HelpLink"), szURLFull);
+                RegSetSZ(hKey, TEXT("HelpLink"), TEXT(HASHCHECK_HELP_URL));
 				RegSetDW(hKey, TEXT("NoModify"), 1);
 				RegSetDW(hKey, TEXT("NoRepair"), 1);
-				RegSetSZ(hKey, TEXT("Publisher"), TEXT("Kai Liu"));
+                RegSetSZ(hKey, TEXT("Publisher"), TEXT(HASHCHECK_PUBLISHER));
 				RegSetSZ(hKey, TEXT("UninstallString"), szUninstall);
-				RegSetSZ(hKey, TEXT("URLInfoAbout"), szURLBase);
+                RegSetSZ(hKey, TEXT("URLInfoAbout"), TEXT(HASHCHECK_ABOUT_URL));
 				RegCloseKey(hKey);
 			}
 

--- a/HashCheck.sln
+++ b/HashCheck.sln
@@ -15,35 +15,23 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "VersionTool", "VersionTool\
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Mixed Platforms = Debug|Mixed Platforms
 		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
-		Release|Mixed Platforms = Release|Mixed Platforms
 		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
-		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Debug|Mixed Platforms.Build.0 = Debug|Win32
 		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Debug|Win32.ActiveCfg = Debug|Win32
 		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Debug|Win32.Build.0 = Debug|Win32
 		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Debug|x64.ActiveCfg = Debug|x64
 		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Debug|x64.Build.0 = Debug|x64
-		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Release|Mixed Platforms.ActiveCfg = Release|Win32
-		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Release|Mixed Platforms.Build.0 = Release|Win32
 		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Release|Win32.ActiveCfg = Release|Win32
 		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Release|Win32.Build.0 = Release|Win32
 		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Release|x64.ActiveCfg = Release|x64
 		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Release|x64.Build.0 = Release|x64
-		{443906DE-5FC8-4DFA-B906-2F2D4A37FF55}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
-		{443906DE-5FC8-4DFA-B906-2F2D4A37FF55}.Debug|Mixed Platforms.Build.0 = Debug|Win32
 		{443906DE-5FC8-4DFA-B906-2F2D4A37FF55}.Debug|Win32.ActiveCfg = Debug|Win32
-		{443906DE-5FC8-4DFA-B906-2F2D4A37FF55}.Debug|Win32.Build.0 = Debug|Win32
 		{443906DE-5FC8-4DFA-B906-2F2D4A37FF55}.Debug|x64.ActiveCfg = Debug|Win32
-		{443906DE-5FC8-4DFA-B906-2F2D4A37FF55}.Release|Mixed Platforms.ActiveCfg = Release|Win32
-		{443906DE-5FC8-4DFA-B906-2F2D4A37FF55}.Release|Mixed Platforms.Build.0 = Release|Win32
 		{443906DE-5FC8-4DFA-B906-2F2D4A37FF55}.Release|Win32.ActiveCfg = Release|Win32
-		{443906DE-5FC8-4DFA-B906-2F2D4A37FF55}.Release|Win32.Build.0 = Release|Win32
 		{443906DE-5FC8-4DFA-B906-2F2D4A37FF55}.Release|x64.ActiveCfg = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution

--- a/HashCheck.sln
+++ b/HashCheck.sln
@@ -11,22 +11,40 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HashCheck", "HashCheck.vcxproj", "{DCAD938F-9032-4AF9-BA67-8C0CF309D986}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "VersionTool", "VersionTool\VersionTool.vcxproj", "{443906DE-5FC8-4DFA-B906-2F2D4A37FF55}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Mixed Platforms = Debug|Mixed Platforms
 		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
+		Release|Mixed Platforms = Release|Mixed Platforms
 		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Debug|Mixed Platforms.Build.0 = Debug|Win32
 		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Debug|Win32.ActiveCfg = Debug|Win32
 		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Debug|Win32.Build.0 = Debug|Win32
 		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Debug|x64.ActiveCfg = Debug|x64
 		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Debug|x64.Build.0 = Debug|x64
+		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Release|Mixed Platforms.Build.0 = Release|Win32
 		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Release|Win32.ActiveCfg = Release|Win32
 		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Release|Win32.Build.0 = Release|Win32
 		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Release|x64.ActiveCfg = Release|x64
 		{DCAD938F-9032-4AF9-BA67-8C0CF309D986}.Release|x64.Build.0 = Release|x64
+		{443906DE-5FC8-4DFA-B906-2F2D4A37FF55}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{443906DE-5FC8-4DFA-B906-2F2D4A37FF55}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{443906DE-5FC8-4DFA-B906-2F2D4A37FF55}.Debug|Win32.ActiveCfg = Debug|Win32
+		{443906DE-5FC8-4DFA-B906-2F2D4A37FF55}.Debug|Win32.Build.0 = Debug|Win32
+		{443906DE-5FC8-4DFA-B906-2F2D4A37FF55}.Debug|x64.ActiveCfg = Debug|Win32
+		{443906DE-5FC8-4DFA-B906-2F2D4A37FF55}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{443906DE-5FC8-4DFA-B906-2F2D4A37FF55}.Release|Mixed Platforms.Build.0 = Release|Win32
+		{443906DE-5FC8-4DFA-B906-2F2D4A37FF55}.Release|Win32.ActiveCfg = Release|Win32
+		{443906DE-5FC8-4DFA-B906-2F2D4A37FF55}.Release|Win32.Build.0 = Release|Win32
+		{443906DE-5FC8-4DFA-B906-2F2D4A37FF55}.Release|x64.ActiveCfg = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/VersionTool/VersionInput.h
+++ b/VersionTool/VersionInput.h
@@ -12,7 +12,11 @@
 **/
 
 /**
-* Edit this file to set the versions and other related important data.
+* Edit this file to set the versions and other related important data. After
+* editing, build and run VersionTool with the project root directory as the
+* first command line argument, and it will re-generate a C/C++ header include
+* (for rc and source code use) as well as an installer include, all with
+* matching data.
 */
 
 #include <string>
@@ -20,13 +24,22 @@
 #include <array>
 #include <cstddef>
 
+/// This must be exactly four components. They're referred to as major, minor,
+/// revision, and build, by convention
 static const std::array<std::size_t, 4> VERSION_COMPONENTS = {3, 0, 1, 1};
 
+/// This vector may be as long as desired within reason - it gets joined to
+/// make the authors list that appears in various places.
 static const std::vector<std::string> AUTHORS = {
     "Kai Liu", "Christopher Gurnee", "David B. Trout", "Tim Schlueter"};
+
+/// This should be whomever's repo is listed below.
 static const auto FORK_MAINTAINER = "Tim Schlueter";
 
 static const auto REPO = "https://github.com/modelrockettier/HashCheck/";
 static const auto RELEASES =
     "https://github.com/modelrockettier/HashCheck/releases";
+
+/// Used in "manual" installation modes, as far as I can tell, to set an
+/// uninstaller.
 static const auto HELPURL = RELEASES; // could set to repo, or a homepage, or...

--- a/VersionTool/VersionInput.h
+++ b/VersionTool/VersionInput.h
@@ -1,0 +1,32 @@
+/**
+* HashCheck Shell Extension - Version Tool
+* Shell extension:
+* Original work copyright (C) Kai Liu.  All rights reserved.
+* Modified work copyright (C) 2014 Christopher Gurnee.  All rights reserved.
+* Modified work copyright (C) 2016 Tim Schlueter.  All rights reserved.
+* Tool:
+* Original work copyright (C) 2016 Ryan Pavlik. All rights reserved.
+*
+* Please refer to readme.txt for information about this source code.
+* Please refer to license.txt for details about distribution and modification.
+**/
+
+/**
+* Edit this file to set the versions and other related important data.
+*/
+
+#include <string>
+#include <vector>
+#include <array>
+#include <cstddef>
+
+static const std::array<std::size_t, 4> VERSION_COMPONENTS = {3, 0, 1, 1};
+
+static const std::vector<std::string> AUTHORS = {
+    "Kai Liu", "Christopher Gurnee", "David B. Trout", "Tim Schlueter"};
+static const auto FORK_MAINTAINER = "Tim Schlueter";
+
+static const auto REPO = "https://github.com/modelrockettier/HashCheck/";
+static const auto RELEASES =
+    "https://github.com/modelrockettier/HashCheck/releases";
+static const auto HELPURL = RELEASES; // could set to repo, or a homepage, or...

--- a/VersionTool/VersionTool.cpp
+++ b/VersionTool/VersionTool.cpp
@@ -1,0 +1,76 @@
+/**
+* HashCheck Shell Extension - Version Tool
+* Shell extension:
+* Original work copyright (C) Kai Liu.  All rights reserved.
+* Modified work copyright (C) 2014 Christopher Gurnee.  All rights reserved.
+* Modified work copyright (C) 2016 Tim Schlueter.  All rights reserved.
+* Tool:
+* Original work copyright (C) 2016 Ryan Pavlik. All rights reserved.
+*
+* Please refer to readme.txt for information about this source code.
+* Please refer to license.txt for details about distribution and modification.
+**/
+
+#include "VersionInput.h"
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+/// Stream some container's elements to a string, joining them with the
+/// separator, but don't put the separator at the end.
+template <typename T>
+inline std::string join(T &&container, std::string const &sep) {
+  std::ostringstream os;
+  for (auto &&elt : std::forward<T>(container)) {
+    os << elt << sep;
+  }
+  // OK, we actually just remove the separator from the end after initially
+  // putting it there. Don't tell anyone.
+  auto ret = os.str();
+  ret.resize(ret.size() - sep.size());
+  return ret;
+}
+
+int main(int argc, char *argv[]) {
+  if (argc < 2) {
+    std::cerr << "Must pass the project root as the first argument!"
+              << std::endl;
+    return -1;
+  }
+  std::string projectRoot = argv[1];
+
+  auto versionFull = join(VERSION_COMPONENTS, ",");
+  auto versionString = join(VERSION_COMPONENTS, ".");
+  auto authorsList = join(AUTHORS, ", ");
+  auto headerName = projectRoot + "/version_generated.h";
+  {
+    std::ofstream header(headerName);
+    if (!header) {
+      std::cerr << "Could not open " << headerName
+                << " to write the generated header to." << std::endl;
+    }
+    std::cout << "Generating " << headerName << " for version " << versionString
+              << std::endl;
+    header << "#define HASHCHECK_ABOUT_URL \"" << REPO << "\"" << std::endl;
+    header << "#define HASHCHECK_HELP_URL \"" << HELPURL << "\"" << std::endl;
+    header << "#define HASHCHECK_PUBLISHER \"" << FORK_MAINTAINER << "\""
+           << std::endl;
+    header << "#define HASHCHECK_COPYRIGHT_STR \"" << authorsList
+        << ". All rights reserved.\"" << std::endl;
+    header << "#define HASHCHECK_AUTHOR_STR \"" << authorsList << ".\""
+           << std::endl;
+    header << "#define HASHCHECK_VERSION_FULL " << versionFull << std::endl;
+    header << "#define HASHCHECK_VERSION_STR \"" << versionString << "\""
+           << std::endl;
+
+    // PE version: MUST be in the form of major.minor
+    header << "#ifdef _USRDLL" << std::endl;
+    header << "#pragma comment(linker, \"/version:" << VERSION_COMPONENTS[0]
+           << "." << VERSION_COMPONENTS[1] << "\")" << std::endl;
+    header << "#endif" << std::endl;
+    header.close();
+  }
+  return 0;
+}

--- a/VersionTool/VersionTool.cpp
+++ b/VersionTool/VersionTool.cpp
@@ -16,6 +16,7 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 
 /// Stream some container's elements to a string, joining them with the
@@ -33,6 +34,64 @@ inline std::string join(T &&container, std::string const &sep) {
   return ret;
 }
 
+struct ComputedElements {
+  std::string versionString;
+  std::string authorsList;
+};
+
+void generateHeader(std::string const &projectRoot, ComputedElements const &c) {
+  auto headerName = projectRoot + "\\version_generated.h";
+  std::ofstream header(headerName);
+  if (!header) {
+    throw std::runtime_error("Could not open " + headerName +
+                             " to write the generated header to.");
+  }
+
+  auto versionFull = join(VERSION_COMPONENTS, ",");
+  std::cout << "Generating " << headerName << std::endl;
+  header << "// GENERATED FILE - Edit VersionInput.h, and build and run the "
+            "VersionTool to re-generate"
+         << std::endl;
+  header << "// Do not edit by hand!" << std::endl;
+  header << "#define HASHCHECK_ABOUT_URL \"" << REPO << "\"" << std::endl;
+  header << "#define HASHCHECK_HELP_URL \"" << HELPURL << "\"" << std::endl;
+  header << "#define HASHCHECK_PUBLISHER \"" << FORK_MAINTAINER << "\""
+         << std::endl;
+  header << "#define HASHCHECK_COPYRIGHT_STR \"" << c.authorsList
+         << ". All rights reserved.\"" << std::endl;
+  header << "#define HASHCHECK_AUTHOR_STR \"" << c.authorsList << ".\""
+         << std::endl;
+  header << "#define HASHCHECK_VERSION_FULL " << versionFull << std::endl;
+  header << "#define HASHCHECK_VERSION_STR \"" << c.versionString << "\""
+         << std::endl;
+
+  // PE version: MUST be in the form of major.minor
+  header << "#ifdef _USRDLL" << std::endl;
+  header << "#pragma comment(linker, \"/version:" << VERSION_COMPONENTS[0]
+         << "." << VERSION_COMPONENTS[1] << "\")" << std::endl;
+  header << "#endif" << std::endl;
+  header.close();
+}
+
+void generateInstallerInclude(std::string const &projectRoot,
+                              ComputedElements const &c) {
+  auto fileName = projectRoot + "\\installer\\version_generated.nsh";
+  std::ofstream include(fileName);
+  if (!include) {
+    throw std::runtime_error("Could not open " + fileName +
+                             " to write the generated NSIS include file to.");
+  }
+  std::cout << "Generating " << fileName << std::endl;
+  include << "; GENERATED FILE - Edit VersionInput.h, and build and run the "
+             "VersionTool to re-generate."
+          << std::endl;
+  include << "; Do not edit by hand!" << std::endl;
+  include << "!define APP_VER " << c.versionString << std::endl;
+  include << "!define APP_RELEASES_URL " << RELEASES << std::endl;
+  include << "!define APP_AUTHORS \"" << c.authorsList << "\"" << std::endl;
+  include.close();
+}
+
 int main(int argc, char *argv[]) {
   if (argc < 2) {
     std::cerr << "Must pass the project root as the first argument!"
@@ -40,37 +99,46 @@ int main(int argc, char *argv[]) {
     return -1;
   }
   std::string projectRoot = argv[1];
-
-  auto versionFull = join(VERSION_COMPONENTS, ",");
-  auto versionString = join(VERSION_COMPONENTS, ".");
-  auto authorsList = join(AUTHORS, ", ");
-  auto headerName = projectRoot + "/version_generated.h";
-  {
-    std::ofstream header(headerName);
-    if (!header) {
-      std::cerr << "Could not open " << headerName
-                << " to write the generated header to." << std::endl;
-    }
-    std::cout << "Generating " << headerName << " for version " << versionString
-              << std::endl;
-    header << "#define HASHCHECK_ABOUT_URL \"" << REPO << "\"" << std::endl;
-    header << "#define HASHCHECK_HELP_URL \"" << HELPURL << "\"" << std::endl;
-    header << "#define HASHCHECK_PUBLISHER \"" << FORK_MAINTAINER << "\""
-           << std::endl;
-    header << "#define HASHCHECK_COPYRIGHT_STR \"" << authorsList
-        << ". All rights reserved.\"" << std::endl;
-    header << "#define HASHCHECK_AUTHOR_STR \"" << authorsList << ".\""
-           << std::endl;
-    header << "#define HASHCHECK_VERSION_FULL " << versionFull << std::endl;
-    header << "#define HASHCHECK_VERSION_STR \"" << versionString << "\""
-           << std::endl;
-
-    // PE version: MUST be in the form of major.minor
-    header << "#ifdef _USRDLL" << std::endl;
-    header << "#pragma comment(linker, \"/version:" << VERSION_COMPONENTS[0]
-           << "." << VERSION_COMPONENTS[1] << "\")" << std::endl;
-    header << "#endif" << std::endl;
-    header.close();
+  // Trim any leading quote
+  if (projectRoot.front() == '"') {
+    projectRoot = projectRoot.substr(1);
   }
-  return 0;
+  // Trim any trailing quote
+  if (projectRoot.back() == '"') {
+    projectRoot.pop_back();
+  }
+  // remove trailing slash/backslash.
+  if (projectRoot.back() == '\\' || projectRoot.back() == '/') {
+    projectRoot.pop_back();
+  }
+
+  auto computed =
+      ComputedElements{join(VERSION_COMPONENTS, "."), join(AUTHORS, ", ")};
+
+  std::cout << "\nGenerating for version " << computed.versionString
+            << std::endl;
+  std::cout << "Project root: " << projectRoot << "\n" << std::endl;
+  /// Even if one file fails, we'll try the other file.
+  int retVal = 0;
+
+  try {
+    generateHeader(projectRoot, computed);
+  } catch (std::exception const &e) {
+    std::cerr << "Error generating header: " << e.what() << std::endl;
+    retVal--;
+  }
+
+  try {
+    generateInstallerInclude(projectRoot, computed);
+  } catch (std::exception const &e) {
+    std::cerr << "Error generating installer include: " << e.what()
+              << std::endl;
+    retVal--;
+  }
+
+  if (0 == retVal) {
+    std::cout << "Completed successfully!" << std::endl;
+  }
+
+  return retVal;
 }

--- a/VersionTool/VersionTool.vcxproj
+++ b/VersionTool/VersionTool.vcxproj
@@ -78,9 +78,6 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <Text Include="ReadMe.txt" />
-  </ItemGroup>
-  <ItemGroup>
     <ClCompile Include="VersionTool.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/VersionTool/VersionTool.vcxproj
+++ b/VersionTool/VersionTool.vcxproj
@@ -1,0 +1,92 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{443906DE-5FC8-4DFA-B906-2F2D4A37FF55}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>VersionTool</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <PrecompiledHeaderFile />
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <PrecompiledHeaderFile />
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <Text Include="ReadMe.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="VersionTool.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="VersionInput.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/VersionTool/VersionTool.vcxproj.filters
+++ b/VersionTool/VersionTool.vcxproj.filters
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="ReadMe.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="VersionTool.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="VersionInput.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/VersionTool/VersionTool.vcxproj.filters
+++ b/VersionTool/VersionTool.vcxproj.filters
@@ -15,9 +15,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <Text Include="ReadMe.txt" />
-  </ItemGroup>
-  <ItemGroup>
     <ClCompile Include="VersionTool.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/buildBoth.cmd
+++ b/buildBoth.cmd
@@ -1,0 +1,18 @@
+@echo off
+rem Clean builds both architectures (release mode)
+
+pushd "%~dp0"
+call "%VS120COMNTOOLS%\vsvars32"
+echo Building 32-bit
+echo.
+msbuild /nologo HashCheck.vcxproj /p:Configuration=Release;Platform=Win32 /t:Clean;Build
+if not errorlevel 0 exit /b 1
+echo.
+
+echo Building 64-bit
+echo.
+msbuild /nologo HashCheck.vcxproj /p:Configuration=Release;Platform=x64 /t:Clean;Build
+if not errorlevel 0 exit /b 1
+echo.
+
+popd

--- a/installer/HashCheck.nsi
+++ b/installer/HashCheck.nsi
@@ -73,7 +73,7 @@ VIAddVersionKey /LANG=${LANG_ENGLISH} "FileVersion" "2.2.2.5"
 Section
 
     GetTempFileName $0
-    File /oname=$0 ..\bin.x86-32\HashCheck.dll
+    File /oname=$0 ..\bin\Win32\Release\HashCheck.dll
     ExecWait 'regsvr32 /i /n /s "$0"'
     IfErrors abort_on_error
     Delete $0
@@ -94,7 +94,7 @@ Section
     ${If} ${RunningX64}
         ${DisableX64FSRedirection}
 
-        File /oname=$0 ..\bin.x86-64\HashCheck.dll
+        File /oname=$0 ..\bin\x64\Release\HashCheck.dll
         ExecWait 'regsvr32 /i /n /s "$0"'
         IfErrors abort_on_error
         Delete $0

--- a/installer/HashCheck.nsi
+++ b/installer/HashCheck.nsi
@@ -52,17 +52,17 @@ FunctionEnd
 !insertmacro MUI_LANGUAGE "Turkish"
 !insertmacro MUI_LANGUAGE "Ukrainian"
 
-!define APP_VER 3.0.1.0
-!define REPO https://github.com/modelrockettier/HashCheck
+; Updated by the VersionTool app from data in
+!include "version_generated.nsh"
 
 VIProductVersion "${APP_VER}"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductName" "HashCheck Shell Extension"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductVersion" "${APP_VER}"
-VIAddVersionKey /LANG=${LANG_ENGLISH} "Comments" "Installer distributed from ${REPO}/releases"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "Comments" "Installer distributed from ${APP_RELEASES_URL}"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "CompanyName" ""
 VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalTrademarks" ""
-VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalCopyright" "Copyright © Kai Liu, Christopher Gurnee, David B. Trout, Tim Schlueter."
-VIAddVersionKey /LANG=${LANG_ENGLISH} "FileDescription" "HashCheck installer (x86/x64), distributed from ${REPO}/releases"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalCopyright" "Copyright © ${APP_AUTHORS}."
+VIAddVersionKey /LANG=${LANG_ENGLISH} "FileDescription" "HashCheck installer (x86/x64), distributed from ${APP_RELEASES_URL}"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "FileVersion" "${APP_VER}"
 
 ; With solid compression, files that are required before the

--- a/installer/HashCheck.nsi
+++ b/installer/HashCheck.nsi
@@ -52,15 +52,18 @@ FunctionEnd
 !insertmacro MUI_LANGUAGE "Turkish"
 !insertmacro MUI_LANGUAGE "Ukrainian"
 
-VIProductVersion "2.2.2.5"
+!define APP_VER 3.0.1.0
+!define REPO https://github.com/modelrockettier/HashCheck
+
+VIProductVersion "${APP_VER}"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductName" "HashCheck Shell Extension"
-VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductVersion" "2.2.2.5"
-VIAddVersionKey /LANG=${LANG_ENGLISH} "Comments" "Installer distributed from https://github.com/chappjc/HashCheck/releases"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductVersion" "${APP_VER}"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "Comments" "Installer distributed from ${REPO}/releases"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "CompanyName" ""
 VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalTrademarks" ""
-VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalCopyright" "Copyright © Kai Liu and Christopher Gurnee."
-VIAddVersionKey /LANG=${LANG_ENGLISH} "FileDescription" "Installer (x86/x64) from https://github.com/chappjc/HashCheck/releases"
-VIAddVersionKey /LANG=${LANG_ENGLISH} "FileVersion" "2.2.2.5"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalCopyright" "Copyright © Kai Liu, Christopher Gurnee, David B. Trout, Tim Schlueter."
+VIAddVersionKey /LANG=${LANG_ENGLISH} "FileDescription" "HashCheck installer (x86/x64), distributed from ${REPO}/releases"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "FileVersion" "${APP_VER}"
 
 ; With solid compression, files that are required before the
 ; actual installation should be stored first in the data block,

--- a/installer/HashCheck.nsi
+++ b/installer/HashCheck.nsi
@@ -5,8 +5,11 @@ SetCompressor /FINAL /SOLID lzma
 
 Unicode true
 
+; Updated by the VersionTool app
+!include "version_generated.nsh"
+
 Name "HashCheck"
-OutFile "HashCheckSetup.exe"
+OutFile "HashCheckSetup-${APP_VER}.exe"
 
 RequestExecutionLevel admin
 ManifestSupportedOS all
@@ -51,9 +54,6 @@ FunctionEnd
 !insertmacro MUI_LANGUAGE "Swedish"
 !insertmacro MUI_LANGUAGE "Turkish"
 !insertmacro MUI_LANGUAGE "Ukrainian"
-
-; Updated by the VersionTool app from data in
-!include "version_generated.nsh"
 
 VIProductVersion "${APP_VER}"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductName" "HashCheck Shell Extension"

--- a/installer/findNsis.cmd
+++ b/installer/findNsis.cmd
@@ -1,0 +1,40 @@
+@echo off
+rem NSIS finding script by Ryan Pavlik
+rem Somewhat inspired by the way vsvars32 works
+
+set NSIS_ROOT=
+call :getNSISHelper32 HKLM > nul 2>&1
+if errorlevel 1 call :getNSISHelper32 HKCU > nul 2>&1
+if errorlevel 1 call :getNSISHelper64 HKLM > nul 2>&1
+if errorlevel 1 call :getNSISHelper64 HKCU > nul 2>&1
+
+goto :eof
+:getNSISHelper32
+rem Retrieve the value from the registry
+for /F "tokens=1,2*" %%i in ('reg query "%1\SOFTWARE\NSIS" /ve') DO (
+	if "%%i"=="(Default)" (
+		SET "NSIS_ROOT=%%k"
+	)
+)
+rem Registry entry, but no file
+if NOT EXIST "%NSIS_ROOT%\makensis.exe" (
+	set NSIS_ROOT=
+)
+rem no luck
+if "%NSIS_ROOT%"=="" exit /B 1
+exit /B 0
+
+:getNSISHelper64
+rem Retrieve the value from the registry
+for /F "tokens=1,2*" %%i in ('reg query "%1\SOFTWARE\Wow6432Node\NSIS" /ve') DO (
+	if "%%i"=="(Default)" (
+		SET "NSIS_ROOT=%%k"
+	)
+)
+rem Registry entry, but no file
+if NOT EXIST "%NSIS_ROOT%\makensis.exe" (
+	set NSIS_ROOT=
+)
+rem no luck
+if "%NSIS_ROOT%"=="" exit /B 1
+exit /B 0

--- a/installer/version_generated.nsh
+++ b/installer/version_generated.nsh
@@ -1,0 +1,5 @@
+; GENERATED FILE - Edit VersionInput.h, and build and run the VersionTool to re-generate.
+; Do not edit by hand!
+!define APP_VER 3.0.1.1
+!define APP_RELEASES_URL https://github.com/modelrockettier/HashCheck/releases
+!define APP_AUTHORS "Kai Liu, Christopher Gurnee, David B. Trout, Tim Schlueter"

--- a/makeRelease.cmd
+++ b/makeRelease.cmd
@@ -1,0 +1,24 @@
+@echo off
+rem Builds and runs the version tool, clean builds both architectures, and builds the installer.
+
+pushd "%~dp0"
+call updateGeneratedVersionFiles
+if not errorlevel 0 exit /b 1
+
+call buildBoth
+if not errorlevel 0 exit /b 1
+
+pushd installer
+call findNsis
+if "%NSIS_ROOT%"=="" (
+	echo Couldn't find an install of NSIS!
+	pause
+	exit /b 1
+)
+echo Building installer
+echo.
+"%NSIS_ROOT%\makensis" HashCheck.nsi
+popd
+
+popd
+pause

--- a/updateGeneratedVersionFiles.cmd
+++ b/updateGeneratedVersionFiles.cmd
@@ -1,4 +1,6 @@
 @echo off
+rem Clean builds and runs the VersionTool.
+
 pushd "%~dp0"
 call "%VS120COMNTOOLS%\vsvars32"
 echo Building VersionTool

--- a/updateGeneratedVersionFiles.cmd
+++ b/updateGeneratedVersionFiles.cmd
@@ -1,0 +1,11 @@
+@echo off
+pushd "%~dp0"
+call "%VS120COMNTOOLS%\vsvars32"
+echo Building VersionTool
+echo.
+msbuild /nologo VersionTool\VersionTool.vcxproj /p:Configuration=Release /t:Clean;Build
+echo.
+echo Running VersionTool
+echo.
+VersionTool\Release\VersionTool "%~dp0"
+popd

--- a/version.h
+++ b/version.h
@@ -8,28 +8,42 @@
  * Please refer to license.txt for details about distribution and modification.
  **/
 
+#include "version_generated.h"
+
 // Full name; this will appear in the version info and control panel
 #define HASHCHECK_NAME_STR "HashCheck Shell Extension"
 
-// Full version: MUST be in the form of major,minor,revision,build
-#define HASHCHECK_VERSION_FULL 2,3,1,1
+#if 0
+#define HASHCHECK_VERSION_MAJOR 3
+#define HASHCHECK_VERSION_MINOR 0
+#define HASHCHECK_VERSION_REVISION 1
+#define HASHCHECK_VERSION_BUILD 1
 
-// String version: May be any suitable string
-#define HASHCHECK_VERSION_STR "2.3.1.1"
-
-#ifdef _USRDLL
-// PE version: MUST be in the form of major.minor
-#pragma comment(linker, "/version:2.3")
+// Uninstaller Info
+#define HASHCHECK_ABOUT_URL "https://github.com/modelrockettier/HashCheck/"
+#define HASHCHECK_HELP_URL "https://github.com/modelrockettier/HashCheck/releases"
+#define HASHCHECK_PUBLISHER "Tim Schlueter"
 #endif
 
 // String used in the "CompanyName" field of the version resource
-#define HASHCHECK_AUTHOR_STR "code.kliu.org"
+//#define HASHCHECK_AUTHOR_STR HASHCHECK_ABOUT_URL
 
 // Tail portion of the copyright string for the version resource
-#define HASHCHECK_COPYRIGHT_STR "Kai Liu and Christopher Gurnee. All rights reserved."
+//#define HASHCHECK_COPYRIGHT_STR "Kai Liu, Christopher Gurnee, David B. Trout, Tim Schlueter. All rights reserved."
 
 // Name of the DLL
 #define HASHCHECK_FILENAME_STR "HashCheck.dll"
+
+// Full version: MUST be in the form of major,minor,revision,build
+//#define HASHCHECK_VERSION_FULL HASHCHECK_VERSION_MAJOR,HASHCHECK_VERSION_MINOR,HASHCHECK_VERSION_REVISION,HASHCHECK_VERSION_BUILD
+
+// String version: May be any suitable string
+//#define HASHCHECK_VERSION_STR (#HASHCHECK_VERSION_MAJOR "." #HASHCHECK_VERSION_MINOR "." #HASHCHECK_VERSION_REVISION "." #HASHCHECK_VERSION_BUILD)
+
+#ifdef _USRDLL
+// PE version: MUST be in the form of major.minor
+//#pragma comment(linker, "/version:3.0")
+#endif
 
 // String used for setup
 #define HASHCHECK_SETUP_STR "HashCheck Shell Extension Setup"

--- a/version_generated.h
+++ b/version_generated.h
@@ -1,0 +1,12 @@
+// GENERATED FILE - Edit VersionInput.h, and build and run the VersionTool to re-generate
+// Do not edit by hand!
+#define HASHCHECK_ABOUT_URL "https://github.com/modelrockettier/HashCheck/"
+#define HASHCHECK_HELP_URL "https://github.com/modelrockettier/HashCheck/releases"
+#define HASHCHECK_PUBLISHER "Tim Schlueter"
+#define HASHCHECK_COPYRIGHT_STR "Kai Liu, Christopher Gurnee, David B. Trout, Tim Schlueter. All rights reserved."
+#define HASHCHECK_AUTHOR_STR "Kai Liu, Christopher Gurnee, David B. Trout, Tim Schlueter."
+#define HASHCHECK_VERSION_FULL 3,0,1,1
+#define HASHCHECK_VERSION_STR "3.0.1.1"
+#ifdef _USRDLL
+#pragma comment(linker, "/version:3.0")
+#endif


### PR DESCRIPTION
OK, so this supercedes/includes the contents of #1 but is entirely more automated and nice. (Try as you might, there are just some things the C preprocessor can't do...)

Now, there's a single place to adjust version, author, etc. info: `VersionTool/VersionInput.h`. Build and run the version tool (there's a batch file for that) and it will spit out a header for the compiler as well as an include file for the installer, so that data will always be in sync. You've got a bunch of new scripts for building and release management, including one that does the whole process (builds and runs the version tool, clean builds both architectures, and finds NSIS and builds the installer, which now even has the version number in the filename).  Should beat the inconsistent data of before, since parts might have said 3.0.1, but if you clicked on Options, it would still say 2.something in there and not point back to this fork... All fixed now.
